### PR TITLE
fix(decoder) Remove an unnecessary bitwise operation.

### DIFF
--- a/webIDL.js
+++ b/webIDL.js
@@ -252,7 +252,7 @@ function polyfill(module, imports, getExports) {
       const bytes = [];
       while (true) {
         const byte = readByte();
-        bytes.push(byte & 0x7f);
+        bytes.push(byte);
         if (!(byte & 0x80)) {
           break;
         }


### PR DESCRIPTION
When reading little-endian bytes in `readLEB`, each byte is `&`-ed to
`0x7f` twice. To see it more cleary, let's unfold the loops for a
single byte; we obtain the following code:

```js
          from the second loop
 ------------------------------------
/                                    \
|                    from the        |
|                   first loop       |
|                  -----------       |
|                 /           \      |
val = (0 << 7) & ((byte & 0x7f) & 0x7f);
```

It can be simplified to:

```js
val = (0 << 7) & (byte & 0x7f);
```

Thus this patch.