### PR TITLE
fix(decoder) `get-field` has 2 arguments: type, and field-index.

### DIFF
--- a/webIDL.js
+++ b/webIDL.js
@@ -386,7 +386,7 @@ function polyfill(module, imports, getExports) {
         };
       } else if (opcode === 0x0c) { // get-field
         debugIndent('get-field');
-        const ty = readLEB();
+        const ty = readType();
         debug('ty =', ty);
         const field = readLEB();
         debug('field =', field);


### PR DESCRIPTION
Based on the `README.md`, `get-field` has 2 arguments: `type` and
`field-index`. The parser in `webIDL.js` doesn't reflect that since it
reads 2 LEB. This patch fixes the first argument type by replacing
`readLEB` by `readType`.